### PR TITLE
cmake: remove STXXL_INCLUDE_DIRS and remove superfluous add_library()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,6 @@ set(USE_OPENMP OFF CACHE BOOL "Don't use OpenMP" FORCE)
 add_subdirectory(third_party/stxxl)
 # apply STXXL CXXFLAGS
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${STXXL_CXX_FLAGS}")
-# add STXXL includes path
-include_directories(${STXXL_INCLUDE_DIRS})
 
 message(STATUS ---)
 message(STATUS "CXX_FLAGS are : " ${CMAKE_CXX_FLAGS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,25 +66,3 @@ target_link_libraries(HasPredicateScanTest gtest_main engine ${CMAKE_THREAD_LIBS
 
 add_executable(MmapVectorTest MmapVectorTest.cpp)
 target_link_libraries(MmapVectorTest gtest_main -pthread)
-
-add_library(tests
-            SparqlParserTest
-            StringUtilsTest
-            LRUCacheTest
-            Simple8bTest
-            FileTest
-            VocabularyTest
-            TsvParserTest
-            ContextFileParserTest
-            IndexMetaDataTest
-            IndexTest
-            EngineTest
-            FTSAlgorithmsTest
-            QueryPlannerTest
-            ConversionsTest
-            SparsehashTest
-            GroupByTest
-            VocabularyGeneratorTest
-            HasPredicateScanTest
-            MmapVectorTest
-            )


### PR DESCRIPTION
Fix problem with missing include: your cmake builds sources without dependencies.